### PR TITLE
Upgrade API to be more production-grade

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ WORKER_RETRIES=3
 WORKER_BACKOFF_S=5
 
 NODE_ENV=development
-API_BASE_URL=http://localhost:3000
+API_BASE_URL=http://localhost:3000/api
 
 # For concurrency test
 PRODUCT_ID=

--- a/.github/workflows/build-and-stage.yml
+++ b/.github/workflows/build-and-stage.yml
@@ -106,6 +106,6 @@ jobs:
       - name: Post-deploy test
         uses: ./.github/actions/wait-for-health
         with:
-          url: http://localhost:${{ vars.API_PORT }}/health
+          url: http://localhost:${{ vars.API_PORT }}/api/health
           attempts: 8
           sleep: 2

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -47,6 +47,6 @@ jobs:
       - name: Post-deploy test
         uses: ./.github/actions/wait-for-health
         with:
-          url: http://localhost:${{ vars.API_PORT }}/health
+          url: http://localhost:${{ vars.API_PORT }}/api/health
           attempts: 8
           sleep: 2

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 .env
 .vagrant
+local/

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ npm run compose:down # Shut down app and infra
 ```
 
 Accessing services:
-- API: http://localhost:3000
+- API: http://localhost:3000/api
 - Postgres: http://localhost:5432
 - RabbitMQ: http://localhost:5672
 - RabbitMQ Web UI: http://localhost:15672
 
-> NOTE: See `.env.example` / `.env` for service credentials.
+> NOTE: See `.env.example` / `.env` for service configuration.
 
 Available one-off jobs:
 - Migrate DB: `docker compose run --rm migrate`
@@ -55,7 +55,7 @@ This project uses a GitHub Actions CI/CD pipeline with separate stages for PR va
   - uses the GitHub `stage` Environment
   - pulls the exact image built in the previous job from GHCR
   - deploys it with `docker compose -f compose.prod.yml -p stage up -d`
-  - performs a post-deploy smoke check against `http://localhost:${API_PORT}/health`
+  - performs a post-deploy smoke check against `http://localhost:${API_PORT}/api/health`
 
 `deploy-prod.yml`
 - Trigger: manual `workflow_dispatch`

--- a/api-collection/Orders/Create Order.bru
+++ b/api-collection/Orders/Create Order.bru
@@ -16,7 +16,6 @@ headers {
 
 body:json {
   {
-    "userId": "69eaf218-2161-40bf-a23e-8af48e459acd",
     "items": [
       {
         "id": "1203f9a8-2389-41f3-b450-a2bef2a3b2e0",

--- a/api-collection/environments/Dev.bru
+++ b/api-collection/environments/Dev.bru
@@ -1,5 +1,5 @@
 vars {
-  baseUrl: http://localhost:3000
+  baseUrl: http://localhost:3000/api
 }
 vars:secret [
   accessToken

--- a/api-collection/environments/Prod.bru
+++ b/api-collection/environments/Prod.bru
@@ -1,5 +1,5 @@
 vars {
-  baseUrl: http://localhost:8081
+  baseUrl: http://localhost:8081/api
 }
 vars:secret [
   accessToken

--- a/api-collection/environments/Stage.bru
+++ b/api-collection/environments/Stage.bru
@@ -1,5 +1,5 @@
 vars {
-  baseUrl: http://localhost:8080
+  baseUrl: http://localhost:8080/api
 }
 vars:secret [
   accessToken

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,7 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "plugins": ["@nestjs/swagger"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
         "@nestjs/typeorm": "^11.0.0",
         "amqplib": "^0.10.9",
         "bcrypt": "^6.0.0",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.15.1",
         "cookie-parser": "^1.4.7",
         "dotenv": "^16.4.5",
         "passport": "^0.7.0",
@@ -2986,6 +2988,12 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/validator": {
+      "version": "13.15.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
+      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
+      "license": "MIT"
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
@@ -4514,6 +4522,25 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/class-validator": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
+      "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/validator": "^13.15.3",
+        "libphonenumber-js": "^1.11.1",
+        "validator": "^13.15.22"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -7659,6 +7686,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.12.41",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.41.tgz",
+      "integrity": "sha512-lsmMmGXBxXIK/VMLEj0kL6MtUs1kBGj1nTCzi6zgQoG1DEwqwt2DQyHxcLykceIxAnfE3hya7NuIh6PpC6S3fA==",
+      "license": "MIT"
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -10730,6 +10763,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.1.3",
+        "@nestjs/swagger": "^11.3.0",
         "@nestjs/typeorm": "^11.0.0",
         "amqplib": "^0.10.9",
         "bcrypt": "^6.0.0",
@@ -2164,6 +2165,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -2336,6 +2343,26 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/passport": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-11.0.5.tgz",
@@ -2442,6 +2469,55 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.3.0.tgz",
+      "integrity": "sha512-SCS8fG2DL/ZF+9l5in09FwPhpBo5i1Gdo8Se3GYlJ2cn+iNTzF7u13QjHo5XI92BN8DN+Gcug+QTcmWmGvZyNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.1",
+        "js-yaml": "4.1.1",
+        "lodash": "4.18.1",
+        "path-to-regexp": "8.4.2",
+        "swagger-ui-dist": "5.32.4"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@nestjs/swagger/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/@nestjs/testing": {
       "version": "11.1.17",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.17.tgz",
@@ -2544,6 +2620,13 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
@@ -3969,7 +4052,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -7526,7 +7608,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9794,6 +9875,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.4.tgz",
+      "integrity": "sha512-0AADFFQNJzExEN49SrD/34Nn9cxNxVLiydYl2MBwSZFPVXNkVwC/EFAjoezGGqE8oDegiDC+p47t8lKObCinMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "@nestjs/typeorm": "^11.0.0",
     "amqplib": "^0.10.9",
     "bcrypt": "^6.0.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.15.1",
     "cookie-parser": "^1.4.7",
     "dotenv": "^16.4.5",
     "passport": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.3",
+    "@nestjs/swagger": "^11.3.0",
     "@nestjs/typeorm": "^11.0.0",
     "amqplib": "^0.10.9",
     "bcrypt": "^6.0.0",

--- a/scripts/concurrency-test.ts
+++ b/scripts/concurrency-test.ts
@@ -13,7 +13,7 @@ if (!PRODUCT_ID) {
   process.exit(1);
 }
 
-const BASE_URL = "http://localhost:3000";
+const BASE_URL = "http://localhost:3000/api";
 const BASE_HEADERS = {
   "Content-Type": "application/json",
 };

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,11 +1,25 @@
 import { Controller, Get } from "@nestjs/common";
 import { Public } from "./auth/decorators";
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiProperty,
+  ApiTags,
+} from "@nestjs/swagger";
+
+class HealthResponseDto {
+  @ApiProperty()
+  ok: true;
+}
 
 @Controller()
+@ApiTags("Health")
 export class AppController {
   @Public()
   @Get("health")
-  health() {
+  @ApiOperation({ summary: "Health check" })
+  @ApiOkResponse({ type: HealthResponseDto })
+  health(): HealthResponseDto {
     return { ok: true };
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { AuthModule } from "./auth/auth.module";
 import { APP_GUARD } from "@nestjs/core";
 import { JwtAuthGuard } from "./auth/jwt-auth.guard";
 import { RolesGuard } from "./auth/roles.guard";
+import { HttpLoggerMiddleware } from "./common/http-logger.middleware";
 
 @Module({
   imports: [
@@ -47,6 +48,7 @@ import { RolesGuard } from "./auth/roles.guard";
 })
 export class AppModule {
   configure(consumer: MiddlewareConsumer) {
+    consumer.apply(HttpLoggerMiddleware).forRoutes("*");
     consumer.apply(CorrelationIdMiddleware).forRoutes("*");
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -16,6 +16,7 @@ import { JwtPayload, Public } from "./decorators";
 import JwtPayloadDto from "./dtos/jwt-payload.dto";
 import { JwtCookieAuthGuard, REFRESH_TOKEN_COOKIE } from "./jwt-auth.guard";
 import { ConfigService } from "@nestjs/config";
+import { ApiCookieAuth } from "@nestjs/swagger";
 
 @Controller("auth")
 export class AuthController {
@@ -53,6 +54,7 @@ export class AuthController {
     };
   }
 
+  @ApiCookieAuth(REFRESH_TOKEN_COOKIE)
   @Public()
   @UseGuards(JwtCookieAuthGuard)
   @Post("refresh")

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -17,13 +17,17 @@ import JwtPayloadDto from "./dtos/jwt-payload.dto";
 import { JwtCookieAuthGuard, REFRESH_TOKEN_COOKIE } from "./jwt-auth.guard";
 import { ConfigService } from "@nestjs/config";
 import {
+  ApiConflictResponse,
   ApiCookieAuth,
   ApiCreatedResponse,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiUnauthorizedResponse,
 } from "@nestjs/swagger";
 import TokenResponseDto from "./dtos/token-response.dto";
 import UserResponseDto from "./dtos/user-response.dto";
+import { ApiErrorResponseDto } from "src/common/api-error-response.dto";
 
 @Controller("auth")
 export class AuthController {
@@ -37,6 +41,11 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Log into system" })
   @ApiOkResponse({ type: TokenResponseDto })
+  @ApiNotFoundResponse({ type: ApiErrorResponseDto })
+  @ApiUnauthorizedResponse({
+    type: ApiErrorResponseDto,
+    description: "Incorrect credentials",
+  })
   async login(
     @Body() logInDto: LogInDto,
     @Res({ passthrough: true }) response: Response,
@@ -56,6 +65,10 @@ export class AuthController {
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: "Create an account" })
   @ApiCreatedResponse({ type: UserResponseDto })
+  @ApiConflictResponse({
+    type: ApiErrorResponseDto,
+    description: "User already exists",
+  })
   async signUp(@Body() signUpDto: SignUpDto): Promise<UserResponseDto> {
     const user = await this.authService.signUp(signUpDto);
     return {
@@ -71,6 +84,7 @@ export class AuthController {
   @UseGuards(JwtCookieAuthGuard)
   @ApiOperation({ summary: "Refresh access token" })
   @ApiOkResponse({ type: TokenResponseDto })
+  @ApiNotFoundResponse({ type: ApiErrorResponseDto })
   @ApiCookieAuth(REFRESH_TOKEN_COOKIE)
   refreshAccessToken(
     @Cookies(REFRESH_TOKEN_COOKIE) refreshToken: string,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -85,7 +85,7 @@ export class AuthController {
   @ApiOperation({ summary: "Refresh access token" })
   @ApiOkResponse({ type: TokenResponseDto })
   @ApiNotFoundResponse({ type: ApiErrorResponseDto })
-  @ApiCookieAuth(REFRESH_TOKEN_COOKIE)
+  @ApiCookieAuth("refresh-token")
   refreshAccessToken(
     @Cookies(REFRESH_TOKEN_COOKIE) refreshToken: string,
     @JwtPayload() payload: JwtPayloadDto,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -16,7 +16,14 @@ import { JwtPayload, Public } from "./decorators";
 import JwtPayloadDto from "./dtos/jwt-payload.dto";
 import { JwtCookieAuthGuard, REFRESH_TOKEN_COOKIE } from "./jwt-auth.guard";
 import { ConfigService } from "@nestjs/config";
-import { ApiCookieAuth } from "@nestjs/swagger";
+import {
+  ApiCookieAuth,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+} from "@nestjs/swagger";
+import TokenResponseDto from "./dtos/token-response.dto";
+import UserResponseDto from "./dtos/user-response.dto";
 
 @Controller("auth")
 export class AuthController {
@@ -27,10 +34,13 @@ export class AuthController {
 
   @Public()
   @Post("login")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "Log into system" })
+  @ApiOkResponse({ type: TokenResponseDto })
   async login(
     @Body() logInDto: LogInDto,
     @Res({ passthrough: true }) response: Response,
-  ) {
+  ): Promise<TokenResponseDto> {
     const result = await this.authService.login(logInDto);
     response.cookie(REFRESH_TOKEN_COOKIE, result.refreshToken, {
       httpOnly: true,
@@ -44,7 +54,9 @@ export class AuthController {
   @Public()
   @Post("sign-up")
   @HttpCode(HttpStatus.CREATED)
-  async signUp(@Body() signUpDto: SignUpDto) {
+  @ApiOperation({ summary: "Create an account" })
+  @ApiCreatedResponse({ type: UserResponseDto })
+  async signUp(@Body() signUpDto: SignUpDto): Promise<UserResponseDto> {
     const user = await this.authService.signUp(signUpDto);
     return {
       id: user.id,
@@ -54,14 +66,16 @@ export class AuthController {
     };
   }
 
-  @ApiCookieAuth(REFRESH_TOKEN_COOKIE)
   @Public()
-  @UseGuards(JwtCookieAuthGuard)
   @Post("refresh")
+  @UseGuards(JwtCookieAuthGuard)
+  @ApiOperation({ summary: "Refresh access token" })
+  @ApiOkResponse({ type: TokenResponseDto })
+  @ApiCookieAuth(REFRESH_TOKEN_COOKIE)
   refreshAccessToken(
     @Cookies(REFRESH_TOKEN_COOKIE) refreshToken: string,
     @JwtPayload() payload: JwtPayloadDto,
-  ) {
+  ): Promise<TokenResponseDto> {
     return this.authService.refreshAccessToken(payload, refreshToken);
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -8,6 +8,7 @@ import { JwtService } from "@nestjs/jwt";
 import { ConfigService } from "@nestjs/config";
 import JwtPayloadDto from "./dtos/jwt-payload.dto";
 import { PasswordService } from "./password.service";
+import TokenResponseDto from "./dtos/token-response.dto";
 
 @Injectable()
 export class AuthService {
@@ -38,7 +39,7 @@ export class AuthService {
     return this.prepareTokenResponse(user);
   }
 
-  private prepareTokenResponse(user: User) {
+  private prepareTokenResponse(user: User): TokenResponseDto {
     const payload: JwtPayloadDto = {
       email: user.email,
       sub: user.id,

--- a/src/auth/dtos/log-in.dto.ts
+++ b/src/auth/dtos/log-in.dto.ts
@@ -1,9 +1,12 @@
 import { IsEmail, IsString } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
 
 export default class LogInDto {
+  @ApiProperty({ example: "user@mail.com" })
   @IsEmail()
   email: string;
 
+  @ApiProperty({ example: "Strong-pass1*" })
   @IsString()
   password: string;
 }

--- a/src/auth/dtos/log-in.dto.ts
+++ b/src/auth/dtos/log-in.dto.ts
@@ -1,4 +1,9 @@
+import { IsEmail, IsString } from "class-validator";
+
 export default class LogInDto {
+  @IsEmail()
   email: string;
+
+  @IsString()
   password: string;
 }

--- a/src/auth/dtos/sign-up.dto.ts
+++ b/src/auth/dtos/sign-up.dto.ts
@@ -1,9 +1,12 @@
 import { IsEmail, IsStrongPassword } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
 
 export default class SignUpDto {
+  @ApiProperty({ example: "user@mail.com" })
   @IsEmail()
   email: string;
 
+  @ApiProperty({ example: "Strong-pass1*" })
   @IsStrongPassword()
   password: string;
 }

--- a/src/auth/dtos/sign-up.dto.ts
+++ b/src/auth/dtos/sign-up.dto.ts
@@ -1,4 +1,9 @@
+import { IsEmail, IsStrongPassword } from "class-validator";
+
 export default class SignUpDto {
+  @IsEmail()
   email: string;
+
+  @IsStrongPassword()
   password: string;
 }

--- a/src/auth/dtos/token-response.dto.ts
+++ b/src/auth/dtos/token-response.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export default class TokenResponseDto {
+  @ApiProperty()
+  accessToken: string;
+
+  @ApiProperty()
+  refreshToken: string;
+
+  @ApiProperty({ example: "Bearer" })
+  tokenType: string;
+
+  @ApiProperty({
+    description: "Access token expiration in seconds",
+    example: 3600,
+  })
+  expiresIn: number;
+}

--- a/src/auth/dtos/user-response.dto.ts
+++ b/src/auth/dtos/user-response.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { UUID } from "crypto";
+import { UserRole } from "src/users/user.entity";
+
+export default class UserResponseDto {
+  @ApiProperty({ example: "0e8fd161-5c56-4dba-8c7a-6f422ea4d8ee" })
+  id: UUID;
+
+  @ApiProperty({ example: "user@mail.com" })
+  email: string;
+
+  @ApiProperty({ enum: UserRole })
+  role: UserRole;
+
+  @ApiProperty({ type: Date })
+  createdAt: Date;
+}

--- a/src/common/api-error-response.dto.ts
+++ b/src/common/api-error-response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+
+export class ApiErrorResponseDto {
+  @ApiProperty({ example: "ERROR_CODE" })
+  code!: string;
+
+  @ApiProperty({ example: "Operation failed" })
+  message!: string;
+
+  @ApiPropertyOptional()
+  details?: Record<string, unknown>;
+
+  @ApiProperty({ example: "0e8fd161-5c56-4dba-8c7a-6f422ea4d8ee" })
+  correlationId!: string;
+}

--- a/src/common/http-logger.middleware.ts
+++ b/src/common/http-logger.middleware.ts
@@ -1,0 +1,14 @@
+import { Injectable, Logger, NestMiddleware } from "@nestjs/common";
+import type { Request, Response, NextFunction } from "express";
+
+@Injectable()
+export class HttpLoggerMiddleware implements NestMiddleware {
+  private readonly logger = new Logger(HttpLoggerMiddleware.name);
+
+  use(req: Request, res: Response, next: NextFunction) {
+    this.logger.log(
+      `${req.ip} ${req.method} ${req.originalUrl} ${JSON.stringify(req.headers)}`,
+    );
+    next();
+  }
+}

--- a/src/debug/debug.controller.ts
+++ b/src/debug/debug.controller.ts
@@ -1,8 +1,10 @@
 import { Body, Controller, Logger, Post } from "@nestjs/common";
+import { ApiBearerAuth } from "@nestjs/swagger";
 import { Roles } from "src/auth/decorators";
 import { ProcessOrderMessageDto } from "src/orders/process-order-message.dto";
 import { RabbitMqService } from "src/rabbit-mq/rabbit-mq.service";
 
+@ApiBearerAuth()
 @Controller("debug")
 export class DebugController {
   private readonly logger: Logger = new Logger(DebugController.name);

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { HttpExceptionFilter } from "./common/http-exception.filter";
 import * as cookieParser from "cookie-parser";
 import { ValidationPipe } from "@nestjs/common";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
+import { REFRESH_TOKEN_COOKIE } from "./auth/jwt-auth.guard";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -24,7 +25,11 @@ async function bootstrap() {
     )
     .setVersion("1.0")
     .addBearerAuth()
-    .addCookieAuth("refreshToken")
+    .addCookieAuth(
+      REFRESH_TOKEN_COOKIE,
+      { type: "apiKey", in: "cookie" },
+      "refresh-token",
+    )
     .build();
   const documentFactory = () => SwaggerModule.createDocument(app, config);
   SwaggerModule.setup("api/docs", app, documentFactory);

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { HttpExceptionFilter } from "./common/http-exception.filter";
 
 import * as cookieParser from "cookie-parser";
 import { ValidationPipe } from "@nestjs/common";
+import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -15,6 +16,18 @@ async function bootstrap() {
   app.use(cookieParser());
 
   app.setGlobalPrefix("api");
+
+  const config = new DocumentBuilder()
+    .setTitle("E-commerce API")
+    .setDescription(
+      "API for managing orders and products of the e-commerce platform.",
+    )
+    .setVersion("1.0")
+    .addBearerAuth()
+    .addCookieAuth("refreshToken")
+    .build();
+  const documentFactory = () => SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup("api/docs", app, documentFactory);
 
   await app.listen(process.env.PORT ?? 3000);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,10 +7,15 @@ import { ValidationPipe } from "@nestjs/common";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
   app.enableShutdownHooks();
+
   app.useGlobalFilters(new HttpExceptionFilter());
   app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));
   app.use(cookieParser());
+
+  app.setGlobalPrefix("api");
+
   await app.listen(process.env.PORT ?? 3000);
 
   // Help dev restarts inside containers release the port promptly.

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,11 +3,13 @@ import { AppModule } from "./app.module";
 import { HttpExceptionFilter } from "./common/http-exception.filter";
 
 import * as cookieParser from "cookie-parser";
+import { ValidationPipe } from "@nestjs/common";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableShutdownHooks();
   app.useGlobalFilters(new HttpExceptionFilter());
+  app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));
   app.use(cookieParser());
   await app.listen(process.env.PORT ?? 3000);
 

--- a/src/orders/create-order.dto.ts
+++ b/src/orders/create-order.dto.ts
@@ -1,17 +1,21 @@
 import { UUID } from "crypto";
 import { IsUUID, IsInt, ValidateNested, Min } from "class-validator";
 import { Type } from "class-transformer";
+import { ApiProperty } from "@nestjs/swagger";
 
 export class OrderItemDto {
+  @ApiProperty({ example: "0e8fd161-5c56-4dba-8c7a-6f422ea4d8ee" })
   @IsUUID()
   id: UUID;
 
+  @ApiProperty({ example: 1 })
   @IsInt()
   @Min(1)
   qty: number;
 }
 
 export class CreateOrderDto {
+  @ApiProperty({ type: [OrderItemDto] })
   @ValidateNested()
   @Type(() => OrderItemDto)
   items: OrderItemDto[];

--- a/src/orders/create-order.dto.ts
+++ b/src/orders/create-order.dto.ts
@@ -1,10 +1,18 @@
 import { UUID } from "crypto";
+import { IsUUID, IsInt, ValidateNested, Min } from "class-validator";
+import { Type } from "class-transformer";
 
-export type OrderItemDtoType = {
+export class OrderItemDto {
+  @IsUUID()
   id: UUID;
+
+  @IsInt()
+  @Min(1)
   qty: number;
-};
+}
 
 export class CreateOrderDto {
-  items: OrderItemDtoType[];
+  @ValidateNested()
+  @Type(() => OrderItemDto)
+  items: OrderItemDto[];
 }

--- a/src/orders/order-response.dto.ts
+++ b/src/orders/order-response.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { UUID } from "crypto";
+import { OrderStatus } from "./order.entity";
+
+export class OrderItemResponseDto {
+  @ApiProperty({ example: "0e8fd161-5c56-4dba-8c7a-6f422ea4d8ee" })
+  productId: UUID;
+
+  @ApiProperty({ example: 1 })
+  qty: number;
+
+  @ApiProperty({ example: "15.30" })
+  purchasePrice: string;
+}
+
+export default class OrderResponseDto {
+  @ApiProperty({ example: "aa6e3d83-e019-469e-ba87-227d3e4c789c" })
+  id: UUID;
+
+  @ApiProperty({ enum: OrderStatus })
+  status: OrderStatus;
+
+  @ApiProperty()
+  idempotencyKey: UUID;
+
+  @ApiProperty()
+  createdAt: Date;
+
+  @ApiProperty()
+  updatedAt: Date;
+
+  @ApiPropertyOptional()
+  processedAt?: Date;
+
+  @ApiProperty({ type: [OrderItemResponseDto] })
+  items: OrderItemResponseDto[];
+}

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -23,15 +23,20 @@ import { UUID } from "crypto";
 import { OrderStatus } from "./order.entity";
 import { JwtPayload } from "src/auth/decorators";
 import {
+  ApiBadRequestResponse,
   ApiBearerAuth,
+  ApiConflictResponse,
   ApiCreatedResponse,
   ApiHeader,
+  ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiParam,
   ApiQuery,
 } from "@nestjs/swagger";
 import OrderResponseDto from "./order-response.dto";
+import { ApiErrorResponseDto } from "src/common/api-error-response.dto";
 
 @ApiBearerAuth()
 @Controller("orders")
@@ -42,6 +47,22 @@ export class OrdersController {
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: "Create order" })
   @ApiCreatedResponse({ type: OrderResponseDto })
+  @ApiBadRequestResponse({
+    type: ApiErrorResponseDto,
+    description: "Missing idempotency-key header",
+  })
+  @ApiNotFoundResponse({
+    type: ApiErrorResponseDto,
+    description: "Product not found",
+  })
+  @ApiConflictResponse({
+    type: ApiErrorResponseDto,
+    description: "Not enough items in stock",
+  })
+  @ApiInternalServerErrorResponse({
+    type: ApiErrorResponseDto,
+    description: "Failed to create order",
+  })
   @ApiHeader({
     name: "idempotency-key",
     required: true,
@@ -67,6 +88,7 @@ export class OrdersController {
   @Get(":id")
   @ApiOperation({ summary: "Get order by ID" })
   @ApiOkResponse({ type: OrderResponseDto })
+  @ApiNotFoundResponse({ type: ApiErrorResponseDto })
   @ApiParam({ name: "id", example: "0e8fd161-5c56-4dba-8c7a-6f422ea4d8ee" })
   async findById(
     @JwtPayload("sub") userId: UUID,

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -22,7 +22,9 @@ import { CreateOrderDto } from "./create-order.dto";
 import { UUID } from "crypto";
 import { OrderStatus } from "./order.entity";
 import { JwtPayload } from "src/auth/decorators";
+import { ApiBearerAuth } from "@nestjs/swagger";
 
+@ApiBearerAuth()
 @Controller("orders")
 export class OrdersController {
   constructor(private readonly ordersService: OrdersService) {}

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -22,15 +22,31 @@ import { CreateOrderDto } from "./create-order.dto";
 import { UUID } from "crypto";
 import { OrderStatus } from "./order.entity";
 import { JwtPayload } from "src/auth/decorators";
-import { ApiBearerAuth } from "@nestjs/swagger";
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiHeader,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+} from "@nestjs/swagger";
+import OrderResponseDto from "./order-response.dto";
 
 @ApiBearerAuth()
 @Controller("orders")
 export class OrdersController {
   constructor(private readonly ordersService: OrdersService) {}
 
-  @HttpCode(HttpStatus.CREATED)
   @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: "Create order" })
+  @ApiCreatedResponse({ type: OrderResponseDto })
+  @ApiHeader({
+    name: "idempotency-key",
+    required: true,
+    example: "f266fcc6-88d2-4dfb-b5c3-05df42cc03b0",
+  })
   async create(
     @JwtPayload("sub") userId: UUID,
     @Body() dto: CreateOrderDto,
@@ -49,6 +65,9 @@ export class OrdersController {
   }
 
   @Get(":id")
+  @ApiOperation({ summary: "Get order by ID" })
+  @ApiOkResponse({ type: OrderResponseDto })
+  @ApiParam({ name: "id", example: "0e8fd161-5c56-4dba-8c7a-6f422ea4d8ee" })
   async findById(
     @JwtPayload("sub") userId: UUID,
     @Param("id", ParseUUIDPipe) id: UUID,
@@ -59,6 +78,13 @@ export class OrdersController {
   }
 
   @Get()
+  @ApiOperation({ summary: "Find orders" })
+  @ApiOkResponse({ type: [OrderResponseDto] })
+  @ApiQuery({ name: "status", required: false, default: OrderStatus.CREATED })
+  @ApiQuery({ name: "page", required: false, default: 1 })
+  @ApiQuery({ name: "limit", required: false, default: 10 })
+  @ApiQuery({ name: "from", required: false })
+  @ApiQuery({ name: "to", required: false })
   async list(
     @JwtPayload("sub") userId: UUID,
     @Query(

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -2,8 +2,14 @@ import { Controller, Get, NotFoundException } from "@nestjs/common";
 import { UsersService } from "./users.service";
 import { JwtPayload } from "src/auth/decorators";
 import JwtPayloadDto from "src/auth/dtos/jwt-payload.dto";
-import { ApiBearerAuth, ApiOkResponse, ApiOperation } from "@nestjs/swagger";
+import {
+  ApiBearerAuth,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+} from "@nestjs/swagger";
 import UserResponseDto from "src/auth/dtos/user-response.dto";
+import { ApiErrorResponseDto } from "src/common/api-error-response.dto";
 
 @ApiBearerAuth()
 @Controller("users")
@@ -13,6 +19,7 @@ export class UsersController {
   @Get("me")
   @ApiOperation({ summary: "Current user info" })
   @ApiOkResponse({ type: UserResponseDto })
+  @ApiNotFoundResponse({ type: ApiErrorResponseDto })
   async me(@JwtPayload() payload: JwtPayloadDto): Promise<UserResponseDto> {
     const user = await this.service.findById(payload.sub);
     if (!user) throw new NotFoundException("User not found");

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -2,7 +2,9 @@ import { Controller, Get, NotFoundException } from "@nestjs/common";
 import { UsersService } from "./users.service";
 import { JwtPayload } from "src/auth/decorators";
 import JwtPayloadDto from "src/auth/dtos/jwt-payload.dto";
+import { ApiBearerAuth } from "@nestjs/swagger";
 
+@ApiBearerAuth()
 @Controller("users")
 export class UsersController {
   constructor(private service: UsersService) {}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -2,7 +2,8 @@ import { Controller, Get, NotFoundException } from "@nestjs/common";
 import { UsersService } from "./users.service";
 import { JwtPayload } from "src/auth/decorators";
 import JwtPayloadDto from "src/auth/dtos/jwt-payload.dto";
-import { ApiBearerAuth } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiOkResponse, ApiOperation } from "@nestjs/swagger";
+import UserResponseDto from "src/auth/dtos/user-response.dto";
 
 @ApiBearerAuth()
 @Controller("users")
@@ -10,7 +11,9 @@ export class UsersController {
   constructor(private service: UsersService) {}
 
   @Get("me")
-  async me(@JwtPayload() payload: JwtPayloadDto) {
+  @ApiOperation({ summary: "Current user info" })
+  @ApiOkResponse({ type: UserResponseDto })
+  async me(@JwtPayload() payload: JwtPayloadDto): Promise<UserResponseDto> {
     const user = await this.service.findById(payload.sub);
     if (!user) throw new NotFoundException("User not found");
     return {


### PR DESCRIPTION
- implemented incoming DTOs validation with `class-validator` and `class-transformer` libs
- setup API docs with OpenAPI and `@nestjs/swagger`
  - prepared DTOs for normal responses and error response (no validation for them for now)
- added global `/api` prefix for all endpoints
- implemented middleware for logging incoming HTTP requests